### PR TITLE
Handle uuid errors

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:allowBackup="false"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
+        android:theme="@style/Theme.Robomask"
         android:dataExtractionRules="@xml/data_extraction_rules"
         tools:targetApi="s">
         <activity

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Robovosk</string>
+    <string name="app_name">Robomask</string>
 
     // Statuses
     <string name="preparing">در حال آماده سازی…</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
     <!-- Make sure the parent theme is correct (e.g., from Material Components) -->
-    <style name="Theme.VoskDemoJarvis" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.Robomask" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
 
         <!-- Primary brand color. -->
         <!-- Ensure these reference colors defined in colors.xml -->

--- a/models/build.gradle
+++ b/models/build.gradle
@@ -19,7 +19,7 @@ android {
 
 tasks.register('genUUID') {
     def uuid = UUID.randomUUID().toString()
-    def odir = file("$buildDir/generated/assets/model-en-us")
+    def odir = file("$buildDir/generated/assets/vosk-model-small-fa-0.42")
     def ofile = file("$odir/uuid")
     doLast {
         mkdir odir


### PR DESCRIPTION
Update `genUUID` task to output `uuid` file to the correct Vosk model directory.

The `genUUID` task was incorrectly placing the generated `uuid` file in the `model-en-us` directory, leading to a "Failed to unpack/load the model::خطا: vosk-model-small-fa-0.42/uuid" error when attempting to load the `vosk-model-small-fa-0.42` model. This change ensures the `uuid` file is generated in the expected location for the Persian Vosk model.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e8195bb-1de7-4cc9-9a6a-ee895f5eaa3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e8195bb-1de7-4cc9-9a6a-ee895f5eaa3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>